### PR TITLE
feat: prerender portfolio pages with Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && vite build --ssr src/entry-server.tsx --outDir dist-ssr && node scripts/prerender.mjs",
     "test": "vitest run",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -4,6 +4,6 @@
     <loc>https://salmanf.com/</loc>
   </url>
   <url>
-    <loc>https://salmanf.com/projects</loc>
+    <loc>https://salmanf.com/projects/</loc>
   </url>
 </urlset>

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,0 +1,60 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const siteUrl = 'https://salmanf.com'
+
+function escapeAttribute(value) {
+  return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;')
+}
+
+function replaceTagAttribute(document, match, attribute, value) {
+  const matchIndex = document.indexOf(match)
+  if (matchIndex === -1) throw new Error(`Could not find ${match}`)
+
+  const tagStart = document.lastIndexOf('<', matchIndex)
+  const tagEnd = document.indexOf('>', matchIndex)
+  const tag = document.slice(tagStart, tagEnd + 1)
+  const updatedTag = tag.replace(new RegExp(`${attribute}="[^"]*"`), `${attribute}="${escapeAttribute(value)}"`)
+
+  return `${document.slice(0, tagStart)}${updatedTag}${document.slice(tagEnd + 1)}`
+}
+
+export function injectPage(template, page) {
+  const canonicalUrl = `${siteUrl}${page.metadata.canonicalPath}`
+  let document = template.replace(/<title>[^<]*<\/title>/, `<title>${page.metadata.title}</title>`)
+
+  document = replaceTagAttribute(document, 'name="description"', 'content', page.metadata.description)
+  document = replaceTagAttribute(document, 'name="robots"', 'content', page.metadata.robots ?? 'index,follow')
+  document = replaceTagAttribute(document, 'rel="canonical"', 'href', canonicalUrl)
+  document = replaceTagAttribute(document, 'property="og:title"', 'content', page.metadata.title)
+  document = replaceTagAttribute(document, 'property="og:description"', 'content', page.metadata.description)
+  document = replaceTagAttribute(document, 'property="og:url"', 'content', canonicalUrl)
+  document = replaceTagAttribute(document, 'name="twitter:title"', 'content', page.metadata.title)
+  document = replaceTagAttribute(document, 'name="twitter:description"', 'content', page.metadata.description)
+
+  return document.replace('<div id="root"></div>', `<div id="root">${page.html}</div>`)
+}
+
+async function prerender() {
+  const template = await readFile(resolve('dist/index.html'), 'utf8')
+  const { render } = await import(pathToFileURL(resolve('dist-ssr/entry-server.js')).href)
+  const routes = [
+    ['/', 'dist/index.html'],
+    ['/projects', 'dist/projects/index.html'],
+  ]
+
+  await Promise.all(
+    routes.map(async ([route, outputPath]) => {
+      const page = injectPage(template, render(route))
+      const output = resolve(outputPath)
+      await mkdir(dirname(output), { recursive: true })
+      await writeFile(output, page)
+      console.log(`Prerendered ${route} -> ${outputPath}`)
+    }),
+  )
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await prerender()
+}

--- a/scripts/prerender.test.mjs
+++ b/scripts/prerender.test.mjs
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { injectPage } from './prerender.mjs'
+
+const template = `<!doctype html><html><head>
+<title>Salman Fatahillah | Full-stack developer</title>
+<meta name="description" content="Home description" />
+<meta name="robots" content="index,follow" />
+<link rel="canonical" href="https://salmanf.com/" />
+<meta property="og:title" content="Home title" />
+<meta property="og:description" content="Home description" />
+<meta property="og:url" content="https://salmanf.com/" />
+<meta name="twitter:title" content="Home title" />
+<meta name="twitter:description" content="Home description" />
+</head><body><div id="root"></div></body></html>`
+
+describe('injectPage', () => {
+  it('adds prerendered markup and route metadata to a built HTML document', () => {
+    const page = injectPage(template, {
+      html: '<main>Projects body</main>',
+      metadata: {
+        title: 'Projects | Salman Fatahillah',
+        description: 'Selected projects.',
+        canonicalPath: '/projects/',
+      },
+    })
+
+    expect(page).toContain('<div id="root"><main>Projects body</main></div>')
+    expect(page).toContain('<title>Projects | Salman Fatahillah</title>')
+    expect(page).toContain('content="Selected projects."')
+    expect(page).toContain('href="https://salmanf.com/projects/"')
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom'
+import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom'
 import Header from './components/Header'
 import Home from './pages/Home'
 import BlogPage from './pages/BlogPage'
@@ -42,9 +42,9 @@ function RouteMetadata() {
   return null
 }
 
-function App() {
+export function AppRoutes() {
   return (
-    <Router>
+    <>
       <RouteMetadata />
       <div className="min-h-screen bg-orange-100 flex flex-col">
         <Header />
@@ -59,7 +59,15 @@ function App() {
         </main>
         <Footer />
       </div>
-    </Router>
+    </>
+  )
+}
+
+function App() {
+  return (
+    <BrowserRouter>
+      <AppRoutes />
+    </BrowserRouter>
   )
 }
 

--- a/src/entry-server.test.tsx
+++ b/src/entry-server.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { render } from './entry-server'
+
+describe('server entry', () => {
+  it('renders the homepage body and metadata at build time', () => {
+    const page = render('/')
+
+    expect(page.html).toContain("Hi, I&#x27;m Salman Fatahillah")
+    expect(page.metadata.canonicalPath).toBe('/')
+  })
+
+  it('renders the Projects page with its own canonical path', () => {
+    const page = render('/projects')
+
+    expect(page.html).toContain('Projects')
+    expect(page.metadata.canonicalPath).toBe('/projects/')
+  })
+})

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -1,0 +1,31 @@
+import { renderToString } from 'react-dom/server'
+import { Router } from 'react-router-dom'
+import { AppRoutes } from './App'
+import { getPageMetadata } from './lib/seo'
+
+const staticNavigator = {
+  createHref: () => '',
+  encodeLocation: (location: { pathname?: string; search?: string; hash?: string }) => ({
+    pathname: location.pathname ?? '',
+    search: location.search ?? '',
+    hash: location.hash ?? '',
+  }),
+  go: () => {},
+  push: () => {},
+  replace: () => {},
+}
+
+export function render(pathname: string) {
+  return {
+    html: renderToString(
+      <Router
+        location={{ pathname, search: '', hash: '', state: null, key: 'static' }}
+        navigator={staticNavigator}
+        static
+      >
+        <AppRoutes />
+      </Router>,
+    ),
+    metadata: getPageMetadata(pathname),
+  }
+}

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -16,7 +16,7 @@ describe('getPageMetadata', () => {
       title: 'Projects | Salman Fatahillah',
       description:
         'Selected software projects by Salman Fatahillah, spanning production web applications, native tools, and data products.',
-      canonicalPath: '/projects',
+      canonicalPath: '/projects/',
     })
   })
 

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -23,7 +23,7 @@ const routeMetadata: Record<string, PageMetadata> = {
     title: 'Projects | Salman Fatahillah',
     description:
       'Selected software projects by Salman Fatahillah, spanning production web applications, native tools, and data products.',
-    canonicalPath: '/projects',
+    canonicalPath: '/projects/',
   },
   '/blog': {
     title: 'Blog | Salman Fatahillah',


### PR DESCRIPTION
## Summary
- prerender the homepage and Projects route into static HTML during the Vite build
- preserve Vite, React, GitHub Pages, and the existing deployment workflow; no Next.js migration
- render route-aware title, description, canonical, Open Graph, Twitter, and robots metadata into each generated document
- serve Projects from a static `/projects/` directory and align its sitemap/canonical URL
- revert the uncommitted homepage copy experiment before this branch was created

## Verification
- `npm test` — 7 passing tests
- `npm run lint` — passes
- `npm run build` — creates `dist/index.html` and `dist/projects/index.html` with rendered page bodies
- `npm audit --omit=dev --audit-level=moderate` — 0 vulnerabilities
- Tailscale preview returns HTTP 200 with prerendered root markup for `/` and `/projects/`

## Notes
- Blog routes remain client-rendered and excluded from the sitemap by design.
- The build emits the pre-existing Browserslist/caniuse-lite staleness notice.