### PR TITLE
chore: update Node actions and React Router

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       # Previous Astro action configuration retained for repository history:
       # with:
       # path: . # The root location of your Astro project inside the repository. (optional)
       # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
       # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.18.1",
+        "react-router-dom": "^7.18.2",
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
@@ -5036,9 +5036,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5058,12 +5058,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.18.1",
+    "react-router-dom": "^7.18.2",
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v4 to v5 and `actions/setup-node` from v4 to v5 so both use the Node 24 action runtime
- Keep the project runtime on Node 24
- Upgrade `react-router-dom` and `react-router` from 7.18.1 to 7.18.2, resolving the high-severity RSC CSRF advisory GHSA-qwww-vcr4-c8h2

## Verification
- `npm ci`
- `npm audit --omit=dev --audit-level=moderate` — passed with 0 production vulnerabilities
- `npm run lint` — passed
- `npm test` — 7 tests passed
- `npm run build` — passed

## Notes
- The full audit including dev dependencies still reports 5 tooling-only vulnerabilities; the existing workflow intentionally audits production dependencies only.
- `configure-pages@v5` and `deploy-pages@v4` remain unchanged because their current releases still declare the Node 20 action runtime.