### PR TITLE
ci: update GitHub Pages actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=moderate
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Upgrade `actions/configure-pages` from v5 to v6
- Upgrade `actions/upload-pages-artifact` from v3 to v5
- Upgrade `actions/deploy-pages` from v4 to v5
- The new configure/deploy releases use the Node 24 action runtime; upload-pages-artifact remains composite

Follow-up to #6, which updated checkout/setup-node and the production React Router dependency.

## Verification
- `npm ci`
- `npm audit --omit=dev --audit-level=moderate` — passed with 0 production vulnerabilities
- `npm run lint` — passed
- `npm test` — 7 tests passed
- `npm run build` — passed
- Verified the referenced action manifests on their live tags

The existing workflow triggers and deployment behavior are unchanged.